### PR TITLE
Moves to Backup everything from PubKey or about PubKey from all available relays.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-nostryfied.online
+nostryfied.amethyst.social

--- a/index.html
+++ b/index.html
@@ -108,10 +108,16 @@
               id="fetching-progress"
               name="fetching-progress"
               min="0"
-              max="300"
+              max="180"
               value="0"
               style="visibility: hidden" />
           </p>
+        </div>
+        <div class="box-content" id="checking-relays-header-box">
+          <p id="checking-relays-header"></p>
+        </div>
+        <div class="box-content" id="checking-relays-box">
+          <p id="checking-relays"></p>
         </div>
         <div class="box-content">
           <p id="file-download"></p>
@@ -125,7 +131,7 @@
               id="broadcasting-progress"
               name="broadcasting-progress"
               min="0"
-              max="300"
+              max="180"
               value="0"
               style="visibility: hidden" />
           </p>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
               id="fetching-progress"
               name="fetching-progress"
               min="0"
-              max="20"
+              max="300"
               value="0"
               style="visibility: hidden" />
           </p>
@@ -125,7 +125,7 @@
               id="broadcasting-progress"
               name="broadcasting-progress"
               min="0"
-              max="20"
+              max="300"
               value="0"
               style="visibility: hidden" />
           </p>
@@ -191,7 +191,7 @@
     <script src="https://bundle.run/buffer@6.0.3"></script>
     <script src="https://bundle.run/bech32@2.0.0"></script>
     <script src="https://nostr-utils.pages.dev/js/jquery-3.6.2.min.js"></script>
-    <script src="https://nostr-utils.pages.dev/js/nostr-utils.js"></script>
+    <script src="js/nostr-utils.js"></script>
     <script src="js/relays.js"></script>
     <script src="js/nostr-broadcast.js"></script>
   </body>

--- a/js/nostr-broadcast.js
+++ b/js/nostr-broadcast.js
@@ -34,10 +34,9 @@ const fetchAndBroadcast = async () => {
 
   // get all events from relays
   const filters =[{ authors: [pubkey] }, { "#p": [pubkey] }] 
-  const data = await getEvents(filters, pubkey)
-
-  const kind3 = data.filter((it) => it.kind == 3 && it.pubkey === pubkey).sort((a, b) => b.created_at - a.created_at)[0]  
-  const myRelaySet = JSON.parse(kind3.content)
+  const data = (await getEvents(filters, pubkey)).sort((a, b) => b.created_at - a.created_at)
+  const latestKind3 = data.filter((it) => it.kind == 3 && it.pubkey === pubkey)[0]  
+  const myRelaySet = JSON.parse(latestKind3.content)
   relays = Object.keys(myRelaySet).filter(url => myRelaySet[url].write).map(url => url)
 
   $('#checking-relays-header-box').css('display', 'none')

--- a/js/nostr-broadcast.js
+++ b/js/nostr-broadcast.js
@@ -34,7 +34,11 @@ const fetchAndBroadcast = async () => {
 
   // get all events from relays
   const filters =[{ authors: [pubkey] }, { "#p": [pubkey] }] 
-  const data = await getEvents(filters)
+  const data = await getEvents(filters, pubkey)
+
+  const kind3 = data.filter((it) => it.kind == 3 && it.pubkey === pubkey).sort((a, b) => b.created_at - a.created_at)[0]  
+  const myRelaySet = JSON.parse(kind3.content)
+  relays = Object.keys(myRelaySet).filter(url => myRelaySet[url].write).map(url => url)
 
   $('#checking-relays-header-box').css('display', 'none')
   $('#checking-relays-box').css('display', 'none')
@@ -53,12 +57,10 @@ const fetchAndBroadcast = async () => {
   
   $('#checking-relays-header-box').css('display', 'flex')
   $('#checking-relays-box').css('display', 'flex')
-  $('#checking-relays-header').text("Waiting for Relays:")
+  $('#checking-relays-header').text("Broadcasting to Relays:")
 
   await broadcastEvents(data)
 
-  $('#checking-relays-header-box').css('display', 'none')
-  $('#checking-relays-box').css('display', 'none')
   // inform user that broadcasting is done
   $('#broadcasting-status').html(txt.broadcasting + checkMark)
   $('#broadcasting-progress').val(relays.length)

--- a/js/nostr-broadcast.js
+++ b/js/nostr-broadcast.js
@@ -36,7 +36,7 @@ const fetchAndBroadcast = async () => {
   // inform user fetching is done
   $('#fetching-status').html(txt.fetching + checkMark)
   clearInterval(fetchInterval)
-  $('#fetching-progress').val(20)
+  $('#fetching-progress').val(300)
   // inform user that backup file (js format) is being downloaded
   $('#file-download').html(txt.download)
   downloadFile(data, 'nostr-backup.js')
@@ -53,7 +53,7 @@ const fetchAndBroadcast = async () => {
   // inform user that broadcasting is done
   $('#broadcasting-status').html(txt.broadcasting + checkMark)
   clearInterval(broadcastInterval)
-  $('#broadcasting-progress').val(20)
+  $('#broadcasting-progress').val(300)
   // re-enable broadcast button
   $('#fetch-and-broadcast').prop('disabled', false)
 }

--- a/js/nostr-broadcast.js
+++ b/js/nostr-broadcast.js
@@ -31,8 +31,8 @@ const fetchAndBroadcast = async () => {
     $('#fetching-progress').val(currValue + 1)
   }, 1000)
   // get all events from relays
-  const filter = { authors: [pubkey] }
-  const data = await getEvents(filter)
+  const filters =[{ authors: [pubkey] }, { "#p": [pubkey] }] 
+  const data = await getEvents(filters)
   // inform user fetching is done
   $('#fetching-status').html(txt.fetching + checkMark)
   clearInterval(fetchInterval)

--- a/js/nostr-broadcast.js
+++ b/js/nostr-broadcast.js
@@ -16,6 +16,7 @@ const fetchAndBroadcast = async () => {
     fetching: 'Fetching from relays... ',
     download: `Downloading Backup file... ${checkMark}`,
   }
+  $('#checking-relays-header').text("Waiting for Relays: ")
   // parse pubkey ('npub' or hexa)
   const pubkey = parsePubkey($('#pubkey').val())
   if (!pubkey) return
@@ -25,18 +26,22 @@ const fetchAndBroadcast = async () => {
   $('#fetching-status').text(txt.fetching)
   // show and update fetching progress bar
   $('#fetching-progress').css('visibility', 'visible')
-  const fetchInterval = setInterval(() => {
-    // update fetching progress bar
-    const currValue = parseInt($('#fetching-progress').val())
-    $('#fetching-progress').val(currValue + 1)
-  }, 1000)
+  $('#fetching-progress').prop('max', relays.length)
+
+  $('#checking-relays-header-box').css('display', 'flex')
+  $('#checking-relays-box').css('display', 'flex')
+  $('#checking-relays-header').text("Waiting for Relays:")
+
   // get all events from relays
   const filters =[{ authors: [pubkey] }, { "#p": [pubkey] }] 
   const data = await getEvents(filters)
+
+  $('#checking-relays-header-box').css('display', 'none')
+  $('#checking-relays-box').css('display', 'none')
+
   // inform user fetching is done
   $('#fetching-status').html(txt.fetching + checkMark)
-  clearInterval(fetchInterval)
-  $('#fetching-progress').val(300)
+  $('#fetching-progress').val(relays.length)
   // inform user that backup file (js format) is being downloaded
   $('#file-download').html(txt.download)
   downloadFile(data, 'nostr-backup.js')
@@ -44,16 +49,19 @@ const fetchAndBroadcast = async () => {
   $('#broadcasting-status').html(txt.broadcasting)
   // show and update broadcasting progress bar
   $('#broadcasting-progress').css('visibility', 'visible')
-  const broadcastInterval = setInterval(() => {
-    // update fetching progress bar
-    const currValue = parseInt($('#broadcasting-progress').val())
-    $('#broadcasting-progress').val(currValue + 1)
-  }, 1000)
+  $('#broadcasting-progress').prop('max', relays.length)
+  
+  $('#checking-relays-header-box').css('display', 'flex')
+  $('#checking-relays-box').css('display', 'flex')
+  $('#checking-relays-header').text("Waiting for Relays:")
+
   await broadcastEvents(data)
+
+  $('#checking-relays-header-box').css('display', 'none')
+  $('#checking-relays-box').css('display', 'none')
   // inform user that broadcasting is done
   $('#broadcasting-status').html(txt.broadcasting + checkMark)
-  clearInterval(broadcastInterval)
-  $('#broadcasting-progress').val(300)
+  $('#broadcasting-progress').val(relays.length)
   // re-enable broadcast button
   $('#fetch-and-broadcast').prop('disabled', false)
 }

--- a/js/nostr-utils.js
+++ b/js/nostr-utils.js
@@ -98,7 +98,7 @@ function hexToBytes(hex) {
             myTimeout = setTimeout(() => {
               ws.close()
               reject('timeout')
-            }, 5_000)
+            }, 10_000)
 
             const { id } = data
 

--- a/js/nostr-utils.js
+++ b/js/nostr-utils.js
@@ -1,0 +1,122 @@
+// from https://github.com/paulmillr/noble-secp256k1/blob/main/index.ts#L803
+function hexToBytes(hex) {
+    if (typeof hex !== 'string') {
+      throw new TypeError('hexToBytes: expected string, got ' + typeof hex)
+    }
+    if (hex.length % 2)
+      throw new Error('hexToBytes: received invalid unpadded hex' + hex.length)
+    const array = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < array.length; i++) {
+      const j = i * 2
+      const hexByte = hex.slice(j, j + 2)
+      const byte = Number.parseInt(hexByte, 16)
+      if (Number.isNaN(byte) || byte < 0) throw new Error('Invalid byte sequence')
+      array[i] = byte
+    }
+    return array
+  }
+  
+  // decode nip19 ('npub') to hex
+  const npub2hexa = (npub) => {
+    let { prefix, words } = bech32.bech32.decode(npub, 90)
+    if (prefix === 'npub') {
+      let data = new Uint8Array(bech32.bech32.fromWords(words))
+      return buffer.Buffer.from(data).toString('hex')
+    }
+  }
+  
+  // encode hex to nip19 ('npub')
+  const hexa2npub = (hex) => {
+    const data = hexToBytes(hex)
+    const words = bech32.bech32.toWords(data)
+    const prefix = 'npub'
+    return bech32.bech32.encode(prefix, words, 90)
+  }
+  
+  // parse inserted pubkey
+  const parsePubkey = (pubkey) =>
+    pubkey.match('npub1') ? npub2hexa(pubkey) : pubkey
+  
+  // download js file
+  const downloadFile = (data, fileName) => {
+    const prettyJs = 'const data = ' + JSON.stringify(data, null, 2)
+    const tempLink = document.createElement('a')
+    const taBlob = new Blob([prettyJs], { type: 'text/javascript' })
+    tempLink.setAttribute('href', URL.createObjectURL(taBlob))
+    tempLink.setAttribute('download', fileName)
+    tempLink.click()
+  }
+  
+  // fetch events from relay, returns a promise
+  const fetchFromRelay = async (relay, filters, events) =>
+    new Promise((resolve, reject) => {
+      try {
+        // prevent hanging forever
+        setTimeout(() => reject('timeout'), 300_000)
+        // open websocket
+        const ws = new WebSocket(relay)
+        // subscription id
+        const subsId = 'my-sub'
+        // subscribe to events filtered by author
+        ws.onopen = () => {
+          ws.send(JSON.stringify(['REQ', subsId].concat(filters)))
+        }
+  
+        // Listen for messages
+        ws.onmessage = (event) => {
+          const [msgType, subscriptionId, data] = JSON.parse(event.data)
+          // event messages
+          if (msgType === 'EVENT' && subscriptionId === subsId) {
+            const { id } = data
+            // prevent duplicated events
+            if (events[id]) return
+            else events[id] = data
+            // show how many events were found until this moment
+            $('#events-found').text(`${Object.keys(events).length} events found`)
+          }
+          // end of subscription messages
+          if (msgType === 'EOSE' && subscriptionId === subsId) resolve()
+        }
+        ws.onerror = (err) => reject(err)
+      } catch (exception) {
+        reject(exception)
+      }
+    })
+  
+  // query relays for events published by this pubkey
+  const getEvents = async (filters) => {
+    // events hash
+    const events = {}
+    // wait for all relays to finish
+    await Promise.allSettled(
+      relays.map((relay) => fetchFromRelay(relay, filters, events))
+    )
+    // return data as an array of events
+    return Object.keys(events).map((id) => events[id])
+  }
+  
+  // send events to a relay, returns a promisse
+  const sendToRelay = async (relay, data) =>
+    new Promise((resolve, reject) => {
+      try {
+        // prevent hanging forever
+        setTimeout(() => reject('timeout'), 20_000)
+        const ws = new WebSocket(relay)
+        // fetch events from relay
+        ws.onopen = () => {
+          for (evnt of data) {
+            ws.send(JSON.stringify(['EVENT', evnt]))
+          }
+          ws.close()
+          resolve(`done for ${relay}`)
+        }
+        ws.onerror = (err) => reject(err)
+      } catch (exception) {
+        reject(exception)
+      }
+    })
+  
+  // broadcast events to list of relays
+  const broadcastEvents = async (data) => {
+    await Promise.allSettled(relays.map((relay) => sendToRelay(relay, data)))
+  }

--- a/js/relays.js
+++ b/js/relays.js
@@ -1,7 +1,8 @@
 // list of paid relays from:
 // https://thebitcoinmanual.com/articles/paid-nostr-relay/
 
-const relays = [
+
+const fixedRelays = [
   'wss://atlas.nostr.land', // paid relay	15000	npub12262qa4uhw7u8gdwlgmntqtv7aye8vdcmvszkqwgs0zchel6mz7s6cgrkj
   'wss://bitcoiner.social', // paid relay	1000	npub1dxs2pygtfxsah77yuncsmu3ttqr274qr5g5zva3c7t5s3jtgy2xszsn4st
   'wss://brb.io',
@@ -43,4 +44,15 @@ const relays = [
   'wss://relay.snort.social',
   'wss://relayer.fiatjaf.com',
   'wss://rsslay.fiatjaf.com',
+  'wss://no.str.cr',
+  'wss://nostr.oxtr.dev',
+  'wss://nostr.mom',
+  'wss://relay.nostr.ch',
+  'wss://relay.nostr.band'
 ]
+
+var relays = []
+
+fetch("https://api.nostr.watch/v1/online")
+     .then(response => response.json())
+     .then(json => relays = fixedRelays.concat(json));

--- a/js/relays.js
+++ b/js/relays.js
@@ -10,6 +10,7 @@ const fixedRelays = [
   'wss://expensive-relay.fiatjaf.com',
   'wss://freedom-relay.herokuapp.com',
   'wss://nos.lol',
+  'wss://a.nos.lol',
   'wss://nostr-2.zebedee.cloud',
   'wss://nostr-pub.wellorder.net',
   'wss://nostr-relay.alekberg.net',


### PR DESCRIPTION
1. Stages the number of relays to connect in blocks, avoiding the time-based progress bar and timeout due to unavailable sockets. 
2. Adds multiple filters option to the base lib to do authors and citations at the same time.
3. Increases the list of fixed relays with a list of all online relays available
4. Broadcasts only to the write relays of the pubkey's latest kind 3. 
5. Displays which relays are active on the screen.
6. Fixes several threading issues of the original code. 